### PR TITLE
fix: change to the built-in moola issuer

### DIFF
--- a/api/deploy.js
+++ b/api/deploy.js
@@ -44,13 +44,14 @@ export default async function deployApi(
     http,
     uploads: scratch,
     board,
+    wallet,
   } = home;
 
   const { INSTALLATION_BOARD_ID,  AUCTION_INSTALLATION_BOARD_ID, CONTRACT_NAME } = installationConstants;
   const auctionHouseInstallation = await E(board).getValue(INSTALLATION_BOARD_ID);
   const secondPriceAuctionInstallation = await E(board).getValue(AUCTION_INSTALLATION_BOARD_ID);
 
-  let moneyIssuer = await E(scratch).get('faucetTokenIssuer');
+  let moneyIssuer = await E(wallet).getIssuer('moola');
   const moneyBrand = await E(moneyIssuer).getBrand();
   const moneyMath = await makeLocalAmountMath(moneyIssuer);
   const pricePerListing = moneyMath.make(2);
@@ -59,12 +60,10 @@ export default async function deployApi(
     listingPrice: pricePerListing,
     auctionInstallation: secondPriceAuctionInstallation,
   });
-  //should  this be here? What if its not moola?
-  const { issuer: moolaIssuer } = makeIssuerKit('moola');
   const { creatorFacet, instance, publicFacet: videoService } =
     await E(zoe).startInstance(
       auctionHouseInstallation,
-      harden({ Money: moolaIssuer }),
+      harden({ Money: moneyIssuer }),
       terms,
     );
 

--- a/ui/src/store/wallet/actions.js
+++ b/ui/src/store/wallet/actions.js
@@ -1,6 +1,6 @@
 import wallet from '../../plugins/wallet';
 import api from '../../plugins/api';
-const moolaPursePetname = ['FungibleFaucet', 'Token'];
+const moolaPursePetname = 'Fun budget';
 const tokenPursePetname = ['OneVideoAuctions', 'Token']
 
 const actions = {

--- a/ui/src/store/wallet/state.js
+++ b/ui/src/store/wallet/state.js
@@ -4,7 +4,7 @@ export default function () {
     zoeInvitationDepositFacetId: '',
     walletSend: {},
     apiSend: {},
-    moolaPursePetname: ['FungibleFaucet', 'Token'],
+    moolaPursePetname: 'Fun budget',
     tokenPursePetname: ['OneVideoAuctions', 'Token'],
     sendInvitationResponse: {}, //this is the sell item invitation response.
   };


### PR DESCRIPTION
This PR changes the `moneyIssuer` to use the built-in moola issuer that is given to users. I was able to successfully buy a `OneVideoAuctions.Token`:

<img width="1266" alt="Screen Shot 2020-11-19 at 11 57 02 AM" src="https://user-images.githubusercontent.com/2441069/99717548-65508400-2a5e-11eb-8fcc-290659ece742.png">

You could change this to still use the FungibleFaucet.Token. The downside there is that you are required to run the Fungible Faucet dapp, and that adds to the difficulty of debugging. So entirely up to you on which issuer should be the moneyIssuer.